### PR TITLE
Pin github workflows to a commit hash instead of version tag for security purpose

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -19,25 +19,25 @@ jobs:
         run: npm install --global yarn
 
       - name: Setup Dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3
         with: { dotnet-version: 6 }
 
       - name: Check out repository code
-        uses: actions/checkout@main
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # main
         with: { fetch-depth: 0 }
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Tag version
         run: |

--- a/.github/workflows/build-provider.yml
+++ b/.github/workflows/build-provider.yml
@@ -16,21 +16,21 @@ jobs:
         run: apk add --no-cache alpine-sdk git bash
 
       - name: Check out repository code
-        uses: actions/checkout@main
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # main
         with: { fetch-depth: 0 }
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Tag version
         run: |

--- a/.github/workflows/library-deployment.yml
+++ b/.github/workflows/library-deployment.yml
@@ -18,28 +18,28 @@ jobs:
         run: sudo apt update && sudo apt install -y bash
 
       - name: Check out repository code
-        uses: actions/checkout@main
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # main
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4
         with:
           go-version: 1.21.x
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 16.x
           registry-url: https://registry.npmjs.org
@@ -48,7 +48,7 @@ jobs:
         run: npm install --global yarn
 
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3
         with:
           dotnet-version: 6
 
@@ -56,7 +56,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y icu-devtools
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0ae58361cdfd39e2950bed97a1e26aa20c3d8955 # v4
         with:
           python-version: 3.9
 
@@ -81,7 +81,7 @@ jobs:
         run: cd sdk/dotnet && dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
       
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           generateReleaseNotes: true
           skipIfReleaseExists: true

--- a/.github/workflows/preprod-deployment.yml
+++ b/.github/workflows/preprod-deployment.yml
@@ -16,7 +16,7 @@ jobs:
         run: apk add --no-cache alpine-sdk git aws-cli bash
 
       - name: Check out repository code
-        uses: actions/checkout@main
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # main
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
@@ -25,14 +25,14 @@ jobs:
         run: rm -rf /github/home/.pulumi
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Tag version
         run: git tag -d `git tag | grep -E '.'` && git tag v0.0.0
@@ -63,7 +63,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/future'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ${{ secrets.PREPROD_AWS_REGION }}
           role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -16,7 +16,7 @@ jobs:
         run: apk add --no-cache alpine-sdk git aws-cli bash
 
       - name: Check out repository code
-        uses: actions/checkout@main
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # main
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
@@ -25,14 +25,14 @@ jobs:
         run: rm -rf /github/home/.pulumi
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Tag version
         run: git tag -d `git tag | grep -E '.'` && git tag v0.0.0
@@ -62,7 +62,7 @@ jobs:
         run: mkdir -p upload/pulumi-plugins && mv package/*/*.tar.gz upload/pulumi-plugins/ && ls -la upload/pulumi-plugins/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         if: github.ref == 'refs/heads/main'
         with:
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: apk add --no-cache alpine-sdk git aws-cli bash
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Treat repo as safe
         run: git config --global --add safe.directory /__w/pulumi-spacelift/pulumi-spacelift
@@ -30,14 +30,14 @@ jobs:
         run: rm -rf /github/home/.pulumi
 
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1
         with:
           repo: pulumi/pulumictl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pulumi
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4
 
       - name: Print pulumictl version
         run: pulumictl get version
@@ -64,7 +64,7 @@ jobs:
         run: mkdir -p upload/pulumi-plugins && mv package/*/*.tar.gz upload/pulumi-plugins/ && ls -la upload/pulumi-plugins/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
This PR pins Github workflows to a specific commit hash instead of version tag, for security purpose.

By pinning Github workflows to a specific commit hash, we should be able to restrict deployment of potentially compromised Github actions in the future. If you have any questions, please reach out to #sec-team-appsec.

Note: If you ever need to manually look up the commit hash for a given action version (tag), you can run:

    git ls-remote https://github.com/<owner>/<repo>.git <tag>

Replace `<owner>`, `<repo>`, and `<tag>` with the appropriate values (for example, `actions/checkout` and `v3`). The output will show the commit SHA corresponding to the tag. Use that SHA in your workflow file, e.g.:

    uses: actions/checkout@<sha> # <tag version>
